### PR TITLE
Fix to avoid using deprecated command

### DIFF
--- a/Java Containerization/scripts/deploy.sh
+++ b/Java Containerization/scripts/deploy.sh
@@ -4,5 +4,5 @@ REGION=$1
 RG_NAME=$2
 
 az group create --name $RG_NAME --location $REGION
-az group deployment create --name "azuredeploy" --resource-group $RG_NAME --template-file "./azuredeploy.json" --parameters "./azuredeploy.parameters.json" --verbose
+az deployment group create --name "azuredeploy" --resource-group $RG_NAME --template-file "./azuredeploy.json" --parameters "./azuredeploy.parameters.json" --verbose
 


### PR DESCRIPTION
- `az group deployment` command will be removed in a future release. Instead, use `az deployment group` command.

https://github.com/Azure/azure-cli/issues/12860
